### PR TITLE
code_verifier and state now explicit

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -158,8 +158,8 @@ func (client *WhisperClient) DoClientCredentialsFlow() (t *oauth2.Token, err err
 }
 
 // GetOAuth2LoginURL retrieves the hydra login url
-func (client *WhisperClient) GetOAuth2LoginURL() (string, error) {
-	return client.oah.getLoginURL()
+func (client *WhisperClient) GetOAuth2LoginParams() (string, string, string, error) {
+	return client.oah.getLoginParams()
 }
 
 // GetOAuth2LogoutURL retrieves the hydra revokeLoginSessions url
@@ -168,8 +168,8 @@ func (client *WhisperClient) GetOAuth2LogoutURL(openidToken, postLogoutRedirectU
 }
 
 // ExchangeCodeForToken retrieves a token provided a valid code
-func (client *WhisperClient) ExchangeCodeForToken(code string) (token Tokens, err error) {
-	return client.oah.exchangeCodeForToken(code)
+func (client *WhisperClient) ExchangeCodeForToken(code, codeVerifier, state string) (token Tokens, err error) {
+	return client.oah.exchangeCodeForToken(code, codeVerifier, state)
 }
 
 // RevokeLoginSessions logs out

--- a/client/client.go
+++ b/client/client.go
@@ -157,9 +157,10 @@ func (client *WhisperClient) DoClientCredentialsFlow() (t *oauth2.Token, err err
 	return oauthConfig.Token(ctx)
 }
 
-// GetOAuth2LoginURL retrieves the hydra login url
-func (client *WhisperClient) GetOAuth2LoginParams() (string, string, string, error) {
-	return client.oah.getLoginParams()
+// GetOAuth2LoginURL retrieves the hydra login url as well as the code_verifier and the state values used to generate such URL
+func (client *WhisperClient) GetOAuth2LoginParams() (loginURL, codeVerifier, state string) {
+	loginURL, codeVerifier, state = client.oah.getLoginParams()
+	return
 }
 
 // GetOAuth2LogoutURL retrieves the hydra revokeLoginSessions url

--- a/client/oauth.go
+++ b/client/oauth.go
@@ -19,19 +19,19 @@ func (oah *oAuthHelper) init(oauthURL, redirectURL *url.URL, clientID, clientSec
 }
 
 // getLoginURL builds the login url to authenticate with whisper
-func (oah *oAuthHelper) getLoginURL() (string, error) {
-	state, nonce, err := misc.GetStateAndNonce()
+func (oah *oAuthHelper) getLoginParams() (url, codeVerifier, state string, err error) {
+	var nonce string
+	state, nonce, err = misc.GetStateAndNonce()
 	if err == nil {
-		codeVerifier, codeChallenge, err := misc.GetCodeVerifierAndChallenge()
-		oah.codeVerifier = codeVerifier
-		oah.state = state
+		var codeChallenge string
+		codeVerifier, codeChallenge, err = misc.GetCodeVerifierAndChallenge()
 
 		if err == nil {
-			return oah.oauth2Client.AuthCodeURL(state, oauth2.SetAuthURLParam("nonce", string(nonce)), oauth2.SetAuthURLParam("code_challenge", codeChallenge), oauth2.SetAuthURLParam("code_challenge_method", "S256")), nil
+			return oah.oauth2Client.AuthCodeURL(state, oauth2.SetAuthURLParam("nonce", string(nonce)), oauth2.SetAuthURLParam("code_challenge", codeChallenge), oauth2.SetAuthURLParam("code_challenge_method", "S256")), codeVerifier, state, err
 		}
 	}
 
-	return "", err
+	return url, codeVerifier, state, err
 }
 
 // getLogoutURL builds the logout url to unauthenticate with whisper
@@ -46,8 +46,8 @@ func (oah *oAuthHelper) getLogoutURL(openidToken, postLogoutRedirectURI string) 
 }
 
 // ExchangeCodeForToken performs the code exchange for an oauth token
-func (oah *oAuthHelper) exchangeCodeForToken(code string) (tokens Tokens, err error) {
-	token, err := oah.oauth2Client.Exchange(context.WithValue(context.Background(), oauth2.HTTPClient, misc.GetNoSSLClient()), code, oauth2.SetAuthURLParam("state", oah.state), oauth2.SetAuthURLParam("code_verifier", string(oah.codeVerifier)))
+func (oah *oAuthHelper) exchangeCodeForToken(code, codeVerifier, state string) (tokens Tokens, err error) {
+	token, err := oah.oauth2Client.Exchange(context.WithValue(context.Background(), oauth2.HTTPClient, misc.GetNoSSLClient()), code, oauth2.SetAuthURLParam("state", state), oauth2.SetAuthURLParam("code_verifier", string(codeVerifier)))
 
 	if err != nil {
 		return

--- a/client/oauth.go
+++ b/client/oauth.go
@@ -19,19 +19,13 @@ func (oah *oAuthHelper) init(oauthURL, redirectURL *url.URL, clientID, clientSec
 }
 
 // getLoginURL builds the login url to authenticate with whisper
-func (oah *oAuthHelper) getLoginParams() (url, codeVerifier, state string, err error) {
-	var nonce string
-	state, nonce, err = misc.GetStateAndNonce()
-	if err == nil {
-		var codeChallenge string
-		codeVerifier, codeChallenge, err = misc.GetCodeVerifierAndChallenge()
+func (oah *oAuthHelper) getLoginParams() (url, codeVerifier, state string) {
+	var nonce, codeChallenge string
+	state, nonce = misc.GetStateAndNonce()
+	codeVerifier, codeChallenge = misc.GetCodeVerifierAndChallenge()
+	url = oah.oauth2Client.AuthCodeURL(state, oauth2.SetAuthURLParam("nonce", string(nonce)), oauth2.SetAuthURLParam("code_challenge", codeChallenge), oauth2.SetAuthURLParam("code_challenge_method", "S256"))
 
-		if err == nil {
-			return oah.oauth2Client.AuthCodeURL(state, oauth2.SetAuthURLParam("nonce", string(nonce)), oauth2.SetAuthURLParam("code_challenge", codeChallenge), oauth2.SetAuthURLParam("code_challenge_method", "S256")), codeVerifier, state, err
-		}
-	}
-
-	return url, codeVerifier, state, err
+	return
 }
 
 // getLogoutURL builds the logout url to unauthenticate with whisper

--- a/client/types.go
+++ b/client/types.go
@@ -39,12 +39,10 @@ type hydraClient struct {
 
 // oAuthHelper holds the info and methods to help integrate with oauth
 type oAuthHelper struct {
-	codeVerifier string
 	oauthURL     *url.URL
 	clientID     string
 	clientSecret string
 	oauth2Client *oauth2.Config
-	state        string
 }
 
 type Tokens struct {

--- a/misc/misc.go
+++ b/misc/misc.go
@@ -69,30 +69,23 @@ func GetAccessTokenFromRequest(r *http.Request) (string, error) {
 	return t, nil
 }
 
-func GetStateAndNonce() (state, nonce string, err error) {
-	st, err := randx.RuneSequence(24, randx.AlphaLower)
-	if err == nil {
-		ne, err := randx.RuneSequence(24, randx.AlphaLower)
-
-		if err == nil {
-			return string(st), string(ne), err
-		}
-	}
-	return "", "", nil
+func GetStateAndNonce() (state, nonce string) {
+	st, _ := randx.RuneSequence(24, randx.AlphaLower) // never gives out error, since max > 0
+	ne, _ := randx.RuneSequence(24, randx.AlphaLower) // never gives out error, since max > 0
+	state = string(st)
+	nonce = string(ne)
+	return
 }
 
-func GetCodeVerifierAndChallenge() (codeVerifier string, codeChallenge string, err error) {
-	cv, err := randx.RuneSequence(48, randx.AlphaLower)
-	if err == nil {
-		codeVerifier = string(cv)
+func GetCodeVerifierAndChallenge() (codeVerifier string, codeChallenge string) {
+	cv, _ := randx.RuneSequence(48, randx.AlphaLower) // never gives out error, since max > 0
+	codeVerifier = string(cv)
 
-		hash := sha256.New()
-		hash.Write([]byte(string(codeVerifier)))
-		codeChallenge = base64.RawURLEncoding.EncodeToString(hash.Sum([]byte{}))
+	hash := sha256.New()
+	hash.Write([]byte(string(codeVerifier)))
+	codeChallenge = base64.RawURLEncoding.EncodeToString(hash.Sum([]byte{}))
 
-		return codeVerifier, codeChallenge, nil
-	}
-	return "", "", err
+	return
 }
 
 func GetNoSSLClient() *http.Client {


### PR DESCRIPTION
Fix #22:

1. `client.GetOAuthLoginURL` modified to `client.GetOAuthParams` which outputs the `login url`, the `code_verifier` and the `state`.

2. Modified `client.ExchangeCodeForToken` to explicit accept the `code_verifier` and `state` params.

3. Removed `state` and `code_verifier` from `oAuthHelper` structure.